### PR TITLE
Migrate to new download location for imagemagick binary

### DIFF
--- a/.github/workflows/app_test.yml
+++ b/.github/workflows/app_test.yml
@@ -16,10 +16,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
-          token: ${{ secrets.QM_TOKEN }}
       - name: init project
         run: ./al init
       - name: Start containers

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN apt install -y libjpeg-dev libcairo2 libcairo-dev imagemagick
 
 # RUN apt install -y imagemagick imagemagick-common
 RUN apt install -y build-essential wget
-RUN wget https://www.imagemagick.org/download/ImageMagick.tar.gz
-RUN tar xvzf ImageMagick.tar.gz
-RUN cd $(tar tzf ImageMagick.tar.gz | head -1) && ./configure && make && make install && ldconfig /usr/local/lib
+RUN wget https://imagemagick.org/archive/binaries/magick
+RUN chmod +x magick
+RUN mv magick /usr/local/bin/magick
 # ENV IMAGEMAGICK_BINARY=/usr/local/bin/magick
 # RUN ln -s /usr/local/bin/magick /usr/local/bin/magick.exe
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ COPY alfred/requirements.txt /
 RUN pip3 install -Ur /requirements.txt
 COPY alfred/otto/requirements.txt /otto_requirements.txt
 RUN pip3 install numpy gizeh pillow
+RUN BEZIER_NO_EXTENSION=true pip3 install bezier
 RUN pip3 install -Ur /otto_requirements.txt
 COPY alfred/otto /otto
 RUN pip install -e /otto/


### PR DESCRIPTION
# magick
Points docker image to new imagemagick binary location.

No longer based on zipped file, downloads binary directly.