### PR TITLE
🪂 Continuous Deployment

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,16 @@
+name: 🪂 Deploy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:
+    types: [published, edited, prereleased]
+
+jobs:
+  build:
+    name: 🔨 Build and deploy to gchr
+    uses: quaternionmedia/.github/.github/workflows/build.yml@main

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -12,5 +12,7 @@ on:
 
 jobs:
   build:
-    name: 🔨 Build and deploy to gchr
+    name: 🔨 Build and deploy to ghcr
     uses: quaternionmedia/.github/.github/workflows/build.yml@main
+    with:
+      submodules: true


### PR DESCRIPTION
# Continuous Deployment
Adds `CD.yml` for continuous deployment

Uses [quaternionmedia/.github/.github/workflows/build.yml](https://github.com/quaternionmedia/.github/blob/main/.github/workflows/build.yml)

Builds and publishes to [ghcr.io/quaternionmedia/alfred](https://github.com/quaternionmedia/alfred/pkgs/container/alfred)